### PR TITLE
[SC64][SW] Add inital fuse support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 **/*.zip
 
 !**/.vscode/tasks.json
+sw/deployer/.idea/
+.idea/

--- a/sw/deployer/Cargo.lock
+++ b/sw/deployer/Cargo.lock
@@ -502,6 +502,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuse_mt"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e098b8dc4cd32e9ba31d9c8cdfef11271d8191233c64c2a671432ff19d354948"
+dependencies = [
+ "fuser",
+ "libc",
+ "log",
+ "threadpool",
+]
+
+[[package]]
+name = "fuser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21370f84640642c8ea36dfb2a6bfc4c55941f476fcf431f6fef25a5ddcf0169b"
+dependencies = [
+ "libc",
+ "log",
+ "memchr",
+ "page_size",
+ "pkg-config",
+ "smallvec",
+ "zerocopy",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +585,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -745,9 +778,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libflate"
@@ -1011,6 +1044,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,6 +1067,16 @@ checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "page_size"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b7663cbd190cfd818d08efa8497f6cd383076688c49a391ef7c0d03cd12b561"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1304,11 +1357,14 @@ dependencies = [
  "crc32fast",
  "ctrlc",
  "encoding_rs",
+ "fuse_mt",
  "hex",
  "image",
  "include-flate",
+ "libc",
  "libftdi1-sys",
  "libusb1-sys",
+ "log",
  "md5",
  "panic-message",
  "rand",
@@ -1483,6 +1539,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -1823,6 +1888,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]

--- a/sw/deployer/Cargo.toml
+++ b/sw/deployer/Cargo.toml
@@ -30,6 +30,11 @@ rust-ini = "0.18.0"
 serial2 = "0.2.26"
 serialport = "4.4.0"
 
+[target.'cfg(unix)'.dependencies]
+fuse_mt = "0.6.1"
+libc = "0.2.161"
+log = "0.4.22"
+
 [profile.release]
 lto = true
 strip = true


### PR DESCRIPTION
PoC/WIP implemenation of fuse support via [fuse-mt](https://github.com/wfraser/fuse-mt/tree/master).

Current limitations and notes:
- This was basically the first doing something in rust, I might have done weird things in the code
- Read only support
- Only unix based operation system are supported. fuser/fuse-mt doesn't support windows. There is [winfsp_wrs](https://github.com/Scille/winfsp_wrs) though, but I didn't look at it yet. 
- Everything is pretty slow. The biggest bottleneck was the `getattr` implementation in directory with many files. (I'm guessing fatfs looks through all files in a directory until it finds the requested one). Caching the file stat entries on a RO filesystem was pretty easy and it improved the permomance. However, it still feels pretty slow.
- Some functions are not implemented (properly)

I tested this on WSL2 (mounting the summercart64 via [usbipd](https://learn.microsoft.com/en-us/windows/wsl/connect-usb#attach-a-usb-device) to WSL2) and accessing the filesystem via `\\wsl.localhost\`

For now I'll probably take a break from this PR before I will implement write support, so feel free to pick up my work and improve/fix it.