### PR TITLE
[SC64][SW] Added rerun-if-changed for bootloader dependency

### DIFF
--- a/sw/deployer/build.rs
+++ b/sw/deployer/build.rs
@@ -1,4 +1,6 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo::rerun-if-changed=../bootloader/src/");
+
     let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
 
     cc::Build::new()


### PR DESCRIPTION
Changes to the bootloader source were not being noticed by cargo when recompiling sc64deployer.

We can use [rerun-if-changed](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed) to instruct cargo to rerun the `build.rs` script if there were any changes to any file inside `bootloader/src/` (recursively).