### PR TITLE
bootloader: Inform controllers of port # through custom joybus cmd.

### DIFF
--- a/sw/bootloader/src/joybus.c
+++ b/sw/bootloader/src/joybus.c
@@ -10,6 +10,7 @@
 
 #define JOYBUS_CMD_INFO             (0x00)
 #define JOYBUS_CMD_STATE            (0x01)
+#define JOYBUS_CMD_PLAYER           (0xF0)
 #define JOYBUS_CMD_RESET            (0xFF)
 
 
@@ -58,6 +59,16 @@ typedef struct __attribute__((packed)) {
         int8_t y;
     } rx;
 } joybus_cmd_state_t;
+
+typedef struct __attribute__((packed)) {
+    joybus_trx_info_t info;
+    struct __attribute__((packed)) {
+        uint8_t bitmask;
+    } tx;
+    struct __attribute__((packed)) {
+        uint8_t previous;
+    } rx;
+} joybus_cmd_player_t;
 
 
 static void joybus_clear_buffer (uint8_t *buffer) {
@@ -162,6 +173,20 @@ bool joybus_get_controller_state (int port, joybus_controller_state_t *state) {
 
     if (joybus_execute_command(port, &cmd, sizeof(cmd))) {
         joybus_copy_controller_state(&cmd, state);
+        return true;
+    }
+
+    return false;
+}
+
+bool joybus_set_controller_player (int port) {
+    joybus_cmd_player_t cmd = { .info = {
+        .cmd = JOYBUS_CMD_PLAYER,
+        .tx = { .length = sizeof(cmd.tx) },
+        .rx = { .length = sizeof(cmd.rx) }
+    }, .tx = { 1 << port } };
+
+    if (joybus_execute_command(port, &cmd, sizeof(cmd))) {
         return true;
     }
 

--- a/sw/bootloader/src/joybus.h
+++ b/sw/bootloader/src/joybus.h
@@ -34,6 +34,7 @@ typedef struct {
 
 bool joybus_get_controller_info (int port, joybus_controller_info_t *info, bool reset);
 bool joybus_get_controller_state (int port, joybus_controller_state_t *state);
+bool joybus_set_controller_player (int port);
 
 
 #endif

--- a/sw/bootloader/src/main.c
+++ b/sw/bootloader/src/main.c
@@ -59,6 +59,10 @@ void main (void) {
             break;
     }
 
+    for (int i = 0; i < 4; i++) {
+        joybus_set_controller_player(i);
+    }
+
     deinit();
 
     boot(&boot_params);


### PR DESCRIPTION
I'm developing my own adapter to connect a Nintendo Switch Online N64 controller to my N64 console. To make the experience completely seamless I wanted to also make the 4 LEDs on the back of the controller indicate the port number that the controller is connected to.

The N64 unfortunately doesn't ever inform the controller of the port number it's connected to, so instead I added a custom command to the bootloader of my SummerCart 64 to do the job. Would you be interested in making that an official part of the firmware?