### PR TITLE
[SC64][FW][SW] Adjust memory map for software modem

### DIFF
--- a/fw/rtl/n64/n64_pi.sv
+++ b/fw/rtl/n64/n64_pi.sv
@@ -262,6 +262,13 @@ module n64_pi (
                     mem_offset <= (-32'h1400_0000) + FLASH_OFFSET;
                     n64_scb.pi_flash_active <= 1'b1;
                 end
+            end else begin //N64 Modem
+                if (n64_pi_dq_in >= 16'h1800 && n64_pi_dq_in < 16'h18E0) begin
+                    read_port <= PORT_MEM;
+                    write_port <= PORT_NONE;
+                    mem_offset <= (-32'h1800_0000) + FLASH_OFFSET;
+                    n64_scb.pi_flash_active <= 1'b1;
+                end
             end
 
             if (n64_scb.cfg_unlock) begin

--- a/sw/controller/src/cfg.c
+++ b/sw/controller/src/cfg.c
@@ -216,6 +216,12 @@ static bool cfg_translate_address (uint32_t *address, uint32_t length, translate
                 return false;
             }
         }
+        if (*address >= 0x18000000 && *address < 0x18E00000) {
+            if ((*address + length) <= 0x18E00000) {
+                *address = *address - 0x18000000 + 0x04000000;
+                return false;
+            }
+        }
         if (*address >= 0x1FFC0000 && *address < 0x1FFE0000) {
             if ((*address + length) <= 0x1FFE0000) {
                 *address = *address - 0x1FFC0000 + 0x04FE0000;


### PR DESCRIPTION
This allows the flash chip to be memory-mapped to the modem rom address when ROM Extended is disabled.

ROM Extended: 0x14000000 (at ROM offset 64MB, for increasing ROM size)
Modem: 0x18000000 (at ROM offset 128MB)

Most of the work is done by N64FlashcartMenu, which is responsible for writing to flash and setting ROM Extended.
Other ROMs can also be written there, such as _open source modem replacement using the USB slot_.

As with the 64DD itself, using a real modem with this enabled can cause conflicts and potential damage.
I'm not sure if this check should be handled here or on N64FlashcartMenu.