### PR TITLE
[SC64][BUILD] Added macOS Universal binary support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      MACOS_UNIVERSAL_BINARY: 1
+
     steps:
       - name: Download SummerCart64 repository
         uses: actions/checkout@v4
@@ -115,6 +118,25 @@ jobs:
       - name: Build deployer
         run: cargo b -r ${{ matrix.build-params }}
         working-directory: sw/deployer
+
+      - name: Build Universal macOS deployer
+        if: ${{ runner.os == 'macOS' && env.MACOS_UNIVERSAL_BINARY == 1 }}
+        working-directory: sw/deployer
+        run: |
+          # 'Build deployer' step has built the aarch64-apple-darwin binary.
+          # We will only build the x86_64 version of deployer and lipo it together.
+          # If Apple introduces new architectures or moves away from arm64, 
+          # this will need to be updated.
+          # 
+          # Add x86_64 architecture to Rust toolchain
+          rustup target add x86_64-apple-darwin
+          # Move the prior created arm64 binary for now
+          mkdir -p target/aarch64-apple-darwin/release
+          mv ${{ matrix.executable }} target/aarch64-apple-darwin/release
+          # Build the x86-64 binary
+          cargo b -r --target x86_64-apple-darwin ${{ matrix.build-params }}
+          # lipo the builds together
+          lipo -create -output ${{ matrix.executable }} -arch arm64 target/aarch64-apple-darwin/release/sc64deployer -arch x86_64 target/x86_64-apple-darwin/release/sc64deployer
 
       - name: Package executable
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
   build-firmware:
     runs-on: ubuntu-latest
 
+    if: "! contains(github.event.head_commit.message, '[skip fw]')"
+
     steps:
       - name: Download SummerCart64 repository
         uses: actions/checkout@v4
@@ -94,6 +96,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    if: "! contains(github.event.head_commit.message, '[skip deployer]')"
+
     env:
       MACOS_UNIVERSAL_BINARY: 1
 
@@ -160,7 +164,7 @@ jobs:
             sw/deployer/package/${{ matrix.package-name }}-${{ steps.version.outputs.replaced }}.${{ matrix.package-extension }}
 
   publish-website:
-    if: github.ref == 'refs/heads/main'
+    if: "github.ref == 'refs/heads/main' && ! contains(github.event.head_commit.message, '[skip web]')"
 
     permissions:
       contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
   build-firmware:
     runs-on: ubuntu-latest
 
-    if: "! contains(github.event.head_commit.message, '[skip fw]')"
+    if: ${{ ! contains(github.event.pull_request.title, '[skip fw]') && (github.event.repository.fork == false) }}
 
     steps:
       - name: Download SummerCart64 repository
@@ -96,7 +96,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    if: "! contains(github.event.head_commit.message, '[skip deployer]')"
+    if: ${{ ! contains(github.event.pull_request.title, '[skip deployer]') }}
 
     env:
       MACOS_UNIVERSAL_BINARY: 1
@@ -164,7 +164,7 @@ jobs:
             sw/deployer/package/${{ matrix.package-name }}-${{ steps.version.outputs.replaced }}.${{ matrix.package-extension }}
 
   publish-website:
-    if: "github.ref == 'refs/heads/main' && ! contains(github.event.head_commit.message, '[skip web]')"
+    if: "github.ref == 'refs/heads/main' && (! contains(github.event.pull_request.title, '[skip web]') && (github.event.repository.fork == false))"
 
     permissions:
       contents: read

--- a/sw/deployer/Cargo.toml
+++ b/sw/deployer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc64deployer"
-version = "2.20.2"
+version = "2.20.3"
 edition = "2021"
 authors = ["Mateusz Faderewski (Polprzewodnikowy)"]
 description = "SummerCart64 loader and control software"


### PR DESCRIPTION
These changes modify the GitHub Actions build workflow to build the macOS Universal binary for sc64deployer. This is to address the issue in #95 around Intel Macs being unable to run sc64deployer and does so by adding the additional Intel 64 bit architecture into the Rust toolchain, running cargo with the architecture, and then lipo'ing the arm64 and x86_64 binaries together.

To minimize risk, an environment variable is introduced to allow for disabling the new step if problems arise and just continue building the arm64 architecture as it currently is done.

I've tested the binary artifact produced by this workflow on my own Intel iMac 5k and M1 Mac Mini and the binary is runnable and seems usable on both. For those interested in testing, you can copy the workflow in your fork, enable GitHub actions, and grab the artifact from the macOS deployers build.

If code signing is ever introduced here (unlikely), this approach may need to be revisited.

@Polprzewodnikowy thanks for creating such a great OSS project. Let me know if there's anything further I can do to assist on this issue.