### PR TITLE
[SC64][FW][SW] Expose STM32 unique device ID in diagnostic data

### DIFF
--- a/docs/02_n64_commands.md
+++ b/docs/02_n64_commands.md
@@ -29,3 +29,12 @@
 | `p` | **FLASH_WAIT_BUSY**   | wait          | ---          | erase_block_size | ---            | Wait until flash ready / get block erase size                |
 | `P` | **FLASH_ERASE_BLOCK** | pi_address    | ---          | ---              | ---            | Start flash block erase                                      |
 | `%` | **DIAGNOSTIC_GET**    | diagnostic_id | ---          | ---              | value          | Get diagnostic data                                          |
+
+### `DIAGNOSTIC_GET` IDs
+
+| diagnostic_id | name                        | value description                                       |
+| ------------- | --------------------------- | ------------------------------------------------------- |
+| `0x00`        | VOLTAGE_TEMPERATURE         | `[31:16]` VDD voltage in mV, `[15:0]` temperature ×10 °C |
+| `0x01`        | UID_WORD_0                  | STM32 unique device ID bits [31:0] (wafer X/Y)          |
+| `0x02`        | UID_WORD_1                  | STM32 unique device ID bits [63:32] (lot number)        |
+| `0x03`        | UID_WORD_2                  | STM32 unique device ID bits [95:64] (lot + wafer)       |

--- a/sw/controller/src/cfg.c
+++ b/sw/controller/src/cfg.c
@@ -94,6 +94,9 @@ typedef enum {
 
 typedef enum {
     DIAGNOSTIC_ID_VOLTAGE_TEMPERATURE = 0,
+    DIAGNOSTIC_ID_UID_WORD_0 = 1,
+    DIAGNOSTIC_ID_UID_WORD_1 = 2,
+    DIAGNOSTIC_ID_UID_WORD_2 = 3,
 } diagnostic_id_t;
 
 typedef enum {
@@ -298,6 +301,14 @@ static bool cfg_read_diagnostic_data (uint32_t *args) {
             int16_t temperature;
             hw_adc_read_voltage_temperature(&voltage, &temperature);
             args[1] = ((uint32_t) (voltage) << 16) | ((uint32_t) (temperature));
+            break;
+        }
+        case DIAGNOSTIC_ID_UID_WORD_0:
+        case DIAGNOSTIC_ID_UID_WORD_1:
+        case DIAGNOSTIC_ID_UID_WORD_2: {
+            uint32_t uid[3];
+            hw_get_uid(uid);
+            args[1] = uid[args[0] - DIAGNOSTIC_ID_UID_WORD_0];
             break;
         }
         default:

--- a/sw/controller/src/hw.c
+++ b/sw/controller/src/hw.c
@@ -564,6 +564,13 @@ void hw_adc_read_voltage_temperature (uint16_t *voltage, int16_t *temperature) {
     ) + (TEMP_CAL_POINT_1 * TEMP_SCALE);
 }
 
+void hw_get_uid (uint32_t uid[3]) {
+    // STM32G030 unique device ID: 96-bit at 0x1FFF7590
+    uid[0] = *((volatile uint32_t *) 0x1FFF7590UL);
+    uid[1] = *((volatile uint32_t *) 0x1FFF7594UL);
+    uid[2] = *((volatile uint32_t *) 0x1FFF7598UL);
+}
+
 
 static void hw_led_init (void) {
     hw_gpio_init(GPIO_ID_LED, GPIO_OUTPUT, GPIO_PP, GPIO_SPEED_VLOW, GPIO_PULL_NONE, GPIO_AF_0, 0);

--- a/sw/controller/src/hw.h
+++ b/sw/controller/src/hw.h
@@ -87,6 +87,7 @@ void hw_reset (loader_parameters_t *parameters);
 void hw_loader_get_parameters (loader_parameters_t *parameters);
 
 void hw_adc_read_voltage_temperature (uint16_t *voltage, int16_t *temperature);
+void hw_get_uid (uint32_t uid[3]);
 
 void hw_primer_init (void);
 void hw_loader_init (void);

--- a/sw/controller/src/usb.c
+++ b/sw/controller/src/usb.c
@@ -25,7 +25,7 @@
 #define DEBUG_WRITE_TIMEOUT_MS  (1000)
 
 #define DIAGNOSTIC_DATA_MARKER  (1 << 31)
-#define DIAGNOSTIC_DATA_VERSION (1)
+#define DIAGNOSTIC_DATA_VERSION (2)
 
 
 enum rx_state {
@@ -568,14 +568,18 @@ static void usb_rx_process (void) {
             case '%': {
                 uint16_t voltage;
                 int16_t temperature;
+                uint32_t uid[3];
                 hw_adc_read_voltage_temperature(&voltage, &temperature);
+                hw_get_uid(uid);
                 p.rx_state = RX_STATE_IDLE;
                 p.response_pending = true;
-                p.response_info.data_length = 16;
+                p.response_info.data_length = 24;
                 p.response_info.data[0] = (DIAGNOSTIC_DATA_MARKER | DIAGNOSTIC_DATA_VERSION);
                 p.response_info.data[1] = (uint32_t) (voltage);
                 p.response_info.data[2] = (uint32_t) (temperature);
-                p.response_info.data[3] = 0;
+                p.response_info.data[3] = uid[0];
+                p.response_info.data[4] = uid[1];
+                p.response_info.data[5] = uid[2];
                 break;
             }
 

--- a/sw/controller/src/usb.h
+++ b/sw/controller/src/usb.h
@@ -21,7 +21,7 @@ typedef enum packet_cmd {
 typedef struct usb_tx_info {
     uint8_t cmd;
     uint32_t data_length;
-    uint32_t data[4];
+    uint32_t data[8];
     uint32_t dma_length;
     uint32_t dma_address;
     void (*done_callback)(void);

--- a/sw/deployer/src/sc64/types.rs
+++ b/sw/deployer/src/sc64/types.rs
@@ -1271,9 +1271,16 @@ pub struct DiagnosticDataV1 {
     pub temperature: f32,
 }
 
+pub struct DiagnosticDataV2 {
+    pub voltage: f32,
+    pub temperature: f32,
+    pub uid: [u32; 3],
+}
+
 pub enum DiagnosticData {
     V0(DiagnosticDataV0),
     V1(DiagnosticDataV1),
+    V2(DiagnosticDataV2),
     Unknown,
 }
 
@@ -1311,6 +1318,23 @@ impl TryFrom<Vec<u8>> for DiagnosticData {
                     temperature: raw_temperature / 10.0,
                 }))
             }
+            2 => {
+                if value.len() != 24 {
+                    return Err(Error::new("Invalid data length for V2 diagnostic data"));
+                }
+                let raw_voltage = u32::from_be_bytes(value[4..8].try_into().unwrap()) as f32;
+                let raw_temperature = u32::from_be_bytes(value[8..12].try_into().unwrap()) as f32;
+                let uid = [
+                    u32::from_be_bytes(value[12..16].try_into().unwrap()),
+                    u32::from_be_bytes(value[16..20].try_into().unwrap()),
+                    u32::from_be_bytes(value[20..24].try_into().unwrap()),
+                ];
+                Ok(DiagnosticData::V2(DiagnosticDataV2 {
+                    voltage: raw_voltage / 1000.0,
+                    temperature: raw_temperature / 10.0,
+                    uid,
+                }))
+            }
             _ => Ok(DiagnosticData::Unknown),
         }
     }
@@ -1331,6 +1355,10 @@ impl Display for DiagnosticData {
             DiagnosticData::V1(d) => f.write_fmt(format_args!(
                 "{:.03} V / {:.01} °C",
                 d.voltage, d.temperature
+            )),
+            DiagnosticData::V2(d) => f.write_fmt(format_args!(
+                "{:.03} V / {:.01} °C / UID: {:08X}{:08X}{:08X}",
+                d.voltage, d.temperature, d.uid[0], d.uid[1], d.uid[2]
             )),
             DiagnosticData::Unknown => f.write_str("Unknown"),
         }


### PR DESCRIPTION
## [SC64][FW][SW] : expose STM32 unique device ID via diagnostic protocol

Adds read access to the STM32G030's factory-programmed 96-bit unique device ID, giving every SC64 unit a persistent, hardware-level identity that cannot be modified by software.

### Changes

- **`hw.c/h`**: `hw_get_uid()` reads the 96-bit UID from the STM32 factory-calibration area at `0x1FFF7590`
- **`usb.c/h`**: Diagnostic protocol bumped to **version 2** (24 bytes); adds UID words 0–2 to the USB debug response. `usb_tx_info_t.data[]` enlarged from 4 → 8 words to accommodate the larger payload
- **`cfg.c`**: Three new diagnostic IDs (`DIAGNOSTIC_ID_UID_WORD_0/1/2`) allow the N64 to read each UID word individually via the existing `DIAGNOSTIC_GET` command
- **`sw/deployer/src/sc64/types.rs`**: Adds `DiagnosticDataV2` struct; V2 is parsed and displayed in `sc64deployer info` as:
  ```
  Diagnostic data:   3.242 V / 44.9 °C / UID: 006200695232501320393936
  ```
- **`docs/02_n64_commands.md`**: Documents all four `DIAGNOSTIC_GET` IDs with value layout

### Notes

> Requires the companion menu PR ([feat/sc64-uid-display](https://github.com/networkfusion/N64FlashcartMenu/pull/new/feat/sc64-uid-display)) to surface the UID in the on-console UI.